### PR TITLE
Bugfixes aggregated

### DIFF
--- a/camocomp/control_points.py
+++ b/camocomp/control_points.py
@@ -16,6 +16,14 @@ import numpy as np
 import cv2
 import hsi
 
+assert 'SURF' in dir(cv2), "SURF is not available in the cv2 package (version {}).\
+                            some linux distribitions removed it as it contains \
+                            properitery algorithms\
+                            In ubuntu do \
+                            sudo add-apt-repository --yes ppa:xqms/opencv-nonfree\
+                            sudo apt-get update \
+                            sudo apt-get install libopencv-nonfree-dev\
+                             ".format(cv2.__version__)
 
 def get_surf_kps(img_fn, img=None, center_out=0,
                  cness_thresh=1000, min_pts=10, max_pts=300):
@@ -31,7 +39,7 @@ def get_surf_kps(img_fn, img=None, center_out=0,
     if img is None:
         img = cv2.imread(img_fn, 0)
     # detect and describe SURF keypoints
-    cvkp, ds = surf.detect(img, None, None)
+    cvkp, ds = surf.detectAndCompute(img, None, None)
     # re-arrange the data properly
     ds.shape = (-1, surf.descriptorSize())  # reshape to (n_pts, desc_size)
     kp = np.array([p.pt for p in cvkp])

--- a/camocomp/motion_compensate.py
+++ b/camocomp/motion_compensate.py
@@ -336,13 +336,14 @@ def generate_stabilized_video(input_media, optim_vars='v_p_y', hfov=40,
                 exec_shell(
                     'ffmpeg -i {} -f image2 -sameq {}/origframe-%06d.jpg'.format(
                         input_media[0], tmp_dir))
-                img_fns = glob('{}/origframe-*.jpg'.format(tmp_dir))
+                img_fns = sorted(glob('{}/origframe-*.jpg'.format(tmp_dir)))
             else:
                 # input arg: assume its directory containing jpg's or png's
                 img_dir = input_media[0]
-                img_fns = glob('{}/*.jpg'.format(img_dir))
+                img_fns = sorted(glob('{}/*.jpg'.format(img_dir)))
                 if len(img_fns) <= 0:
-                    img_fns = glob('{}/*.png'.format(img_dir))
+                    img_fns = sorted(glob('{}/*.png'.format(img_dir)))
+        #otherwise a list of images was given
         else:
             img_fns = input_media
 

--- a/camocomp/motion_compensate.py
+++ b/camocomp/motion_compensate.py
@@ -290,7 +290,7 @@ def warp_crop_and_generate_video(out_avi, optim_proj_file, n_imgs,
     # generate the warped and cropped video
     # Note: directly cropping in ffmpeg (-croptop ...) doesn't work
     # TODO try: -vf crop=...?
-    cmd = "ffmpeg -y -f image2 -i {rit} -vcodec {codec} -sameq -r 25 -an {avi}"
+    cmd = "ffmpeg -y -f image2 -i {rit} -vcodec {codec} -qscale 0 -r 25 -an {avi}"
     exec_shell(cmd.format(rit=rimgt, codec=out_codec, avi=out_avi))
     print "saved {0}".format(out_avi)
 
@@ -333,9 +333,9 @@ def generate_stabilized_video(input_media, optim_vars='v_p_y', hfov=40,
         if len(input_media) == 1:
             if input_media[0][-4:] in ('.avi', 'mpg', '.mp4'):
                 # input arg == a video: dumps its frames
-                exec_shell(
-                    'ffmpeg -i {} -f image2 -sameq {}/origframe-%06d.jpg'.format(
-                        input_media[0], tmp_dir))
+                cmd = 'ffmpeg -i {} -f image2 -qscale 0 {}/origframe-%06d.jpg'.format(input_media[0], tmp_dir)
+                exec_shell(cmd)
+
                 img_fns = glob('{}/origframe-*.jpg'.format(tmp_dir))
             else:
                 # input arg: assume its directory containing jpg's or png's


### PR DESCRIPTION
Added a couple of fixes I needed to do to get the code running on Ubuntu 14.04, opencv 2.4.8, ffmpeg 1.2.6-7:1.2.6-1
- ffmpeg no longer support the 'sameq' option, changed into '-qscale 0'
- openCVs surf.detect() no longer detects point+ computes fatures; changed to surf.detectAndCompute()
- also under ubuntu, the openCV package does not contain the SURF functions, added some assert to give a proper error message
- python's glob() seems to return the files in random order in unix-systems. Put a sorted() around the glob call to preserve the temporal ordering of the images
